### PR TITLE
담당 기능 API 문서 및 팀멤버 서비스 클래스 수정

### DIFF
--- a/src/main/java/com/prolog/prologbackend/Exception/ErrorResponse.java
+++ b/src/main/java/com/prolog/prologbackend/Exception/ErrorResponse.java
@@ -1,10 +1,14 @@
 package com.prolog.prologbackend.Exception;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+@Schema(title = "ErrorResponse : 에러 정보 DTO")
 @Getter
 public class ErrorResponse {
+    @Schema(description = "에러 코드", example = "400")
     private int errorCode;
+    @Schema(description = "에러 메시지", example = "String")
     private String errorMessage;
 
     private ErrorResponse(int errorCode, String errorMessage){

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
@@ -1,5 +1,6 @@
 package com.prolog.prologbackend.Member.Controller;
 
+import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.MemberJoinDto;
 import com.prolog.prologbackend.Member.Service.AnyMemberService;
 import com.prolog.prologbackend.Security.Jwt.JwtType;
@@ -27,72 +28,76 @@ import org.springframework.web.bind.annotation.*;
 public class AnyMemberController {
     private final AnyMemberService anyMemberService;
 
-    @Operation(summary = "회원 가입 메서드")
+    @Operation(summary = "일반 회원 가입 메서드", description = "일반 회원 가입을 통해 회원을 등록합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created : 일반 회원가입 성공"),
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 존재하는 회원",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation= ErrorResponse.class)))
     })
     @PostMapping("/signup")
-    ResponseEntity joinMember(@Valid @RequestBody MemberJoinDto joinDto){
+    ResponseEntity<Void> joinMember(@Valid @RequestBody MemberJoinDto joinDto){
         anyMemberService.joinMember(joinDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "카카오 소셜 회원가입 및 로그인 메서드")
+    @Operation(summary = "카카오 소셜 회원가입 및 로그인", description = "카카오 소셜 로그인을 통해 회원 등록 및 로그인 합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created : 소셜 로그인 성공")
     })
-    @Parameter(name = "인증 코드", description = "카카오 서버 인증에 필요한 코드", example = "kakaoCodeKakaoCode", required = true)
     @PostMapping("/login/oauth/kakao")
-    ResponseEntity socialLoginMember(@RequestParam String code, HttpServletResponse response){
+    ResponseEntity<Void> socialLoginMember(
+            @Parameter(description = "카카오 서버 인증에 필요한 코드", example = "kakaoCodeKakaoCode", required = true)
+            @RequestParam String code, HttpServletResponse response){
         String[] tokens = anyMemberService.loginToKaKao(code);
         response.addHeader(JwtType.ACCESS_TOKEN.getTokenType(),tokens[0]);
         response.addHeader(JwtType.REFRESH_TOKEN.getTokenType(),tokens[1]);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "회원 가입 시 이메일 검증 메서드")
+    @Operation(summary = "이메일 사용 가능 여부 조회", description = "사용 가능한 이메일인지 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 사용 가능한 이메일"),
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 사용중인 이메일",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Parameter(name = "회원 이메일", description = "사용중인지 확인하고 싶은 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
     @GetMapping("/email")
-    ResponseEntity validateEmail(@RequestParam @Email String email){
+    ResponseEntity<Void> validateEmail(
+            @Parameter(description = "사용중인지 확인하고 싶은 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
+            @RequestParam @Email String email){
         if (anyMemberService.validateEmail(email))
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         else
             return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "닉네임 중복 확인 메서드")
+    @Operation(summary = "닉네임 사용 가능 여부 조회", description = "사용 가능한 닉네임인지 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 사용 가능한 닉네임"),
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 사용중인 닉네임",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Parameter(name = "회원 닉네임", description = "사용중인지 확인하고 싶은 닉네임", example = "kimLeeChoi21", required = true)
     @GetMapping("/nickname")
-    ResponseEntity validateNickname(@RequestParam @NotBlank @Size(max=20, message="닉네임은 20자 미만으로 작성해야 합니다.") String nickname) {
+    ResponseEntity<Void> validateNickname(
+            @Parameter(description = "사용중인지 확인하고 싶은 닉네임", example = "kimLeeChoi21", required = true)
+            @RequestParam @NotBlank @Size(max=20, message="닉네임은 20자 미만으로 작성해야 합니다.") String nickname) {
         if(anyMemberService.validateNickname(nickname))
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         else
             return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "이메일 인증 확인 메서드")
+    @Operation(summary = "이메일 검증", description = "서비스 이용을 위한 회원 가입한 이메일의 검증을 진행합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 이메일 인증 성공"),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
-                    content = @Content(schema = @Schema(implementation=Void.class))),
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class))),
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 인증된 이메일",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Schema(description = "Path Variable. 이메일 인증을 위해 발급받은 토큰", example = "verificationTokenVerificationEmailToken")
     @PatchMapping("/verification/{token}")
-    ResponseEntity verificationEmail(@PathVariable String token){
+    ResponseEntity<Void> verificationEmail(
+            @Schema(description = "이메일 인증을 위해 발급받은 토큰", example = "verificationTokenVerificationEmailToken")
+            @PathVariable String token){
         anyMemberService.verificationEmail(token);
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.prolog.prologbackend.Member.Controller;
 
+import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.MemberUpdateDto;
 import com.prolog.prologbackend.Member.DTO.Response.SimpleMemberDto;
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
     private final MemberService memberService;
 
-    @Operation(summary = "로그인한 사용자 정보 조회 메서드")
+    @Operation(summary = "사용자 정보 조회 메서드", description = "로그인한 사용자의 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 사용자 정보 조회 성공",
                     content = @Content(schema = @Schema(implementation=SimpleMemberDto.class)))
@@ -35,32 +38,44 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(SimpleMemberDto.of(member));
     }
 
-    @Operation(summary = "회원 정보 수정 메서드")
+    @Operation(summary = "회원 정보 수정 메서드", description = "사용자는 자신의 정보 중 일부 또는 전부를 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 정보 수정 성공"),
             @ApiResponse(responseCode = "409", description = "Conflict : 변경하려는 이메일이 이미 사용중임",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation= ErrorResponse.class)))
     })
     @PatchMapping("/information")
-    ResponseEntity updateMember(@AuthenticationPrincipal Member member,
+    ResponseEntity<Void> updateMember(@AuthenticationPrincipal Member member,
                                 @RequestBody @Valid MemberUpdateDto dto){
         memberService.updateMember(member.getEmail(), dto);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "회원 탈퇴 메서드")
+    @Operation(summary = "회원 탈퇴 메서드", description = "서비스 이용 중지를 위한 회원 탈퇴를 진행합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 회원 탈퇴 성공")
     })
     @DeleteMapping
-    ResponseEntity withdrawMember(@AuthenticationPrincipal Member member){
+    ResponseEntity<Void> withdrawMember(@AuthenticationPrincipal Member member){
         memberService.deleteMember(member);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @PatchMapping("/image")
-    ResponseEntity updateProfileImage(@AuthenticationPrincipal Member member,
-                                            @RequestPart(value = "image") MultipartFile image){
+    @Operation(summary = "프로필 이미지 수정 메서드", description = "프로필 이미지의 수정 또는 초기화를 진행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok : 이미지 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "Bad Request : S3 이미지 등록 실패",
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Not Found : 일치하는 회원이 없음",
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Conflict : 이미 기본이미지인 경우",
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
+    })
+    @PatchMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<Void> updateProfileImage(
+            @AuthenticationPrincipal Member member,
+            @Parameter(description = "이미지 수정을 위해 새로 적용할 multipart/form-data 형식의 이미지 파일")
+            @RequestPart(value = "image") MultipartFile image){
         if(image.isEmpty())
             memberService.resetProfileImage(member.getEmail());
         else

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/SearchMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/SearchMemberController.java
@@ -1,5 +1,6 @@
 package com.prolog.prologbackend.Member.Controller;
 
+import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.PasswordUpdateDto;
 import com.prolog.prologbackend.Member.Service.SearchMemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,72 +24,79 @@ import org.springframework.web.bind.annotation.*;
 public class SearchMemberController {
     private final SearchMemberService searchMemberService;
 
-    @Operation(summary = "이메일 찾기 메서드")
+    @Operation(summary = "이메일 찾기 메서드", description = "사용자 정보를 이용하여 올바른 사용자에 한해 이메일을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 이메일 찾기 완료"),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Parameter(name = "회원 닉네임", description = "회원 정보 확인을 위한 닉네임", example = "kimLeeChoi21", required = true)
-    @Parameter(name = "회원 핸드폰 번호", description = "회원 정보 확인을 위한 핸드폰 번호", example = "010-1234-5678", required = true)
     @GetMapping("/email")
-    ResponseEntity searchEmail(@RequestParam @NotBlank String nickname, @RequestParam @NotBlank String phone){
+    ResponseEntity searchEmail(
+            @Parameter(description = "회원 정보 확인을 위한 닉네임", example = "kimLeeChoi21", required = true)
+            @RequestParam @NotBlank String nickname,
+            @Parameter(description = "회원 정보 확인을 위한 핸드폰 번호", example = "010-1234-5678", required = true)
+            @RequestParam @NotBlank String phone){
         return ResponseEntity.status(HttpStatus.OK).body(searchMemberService.findEmail(nickname, phone));
     }
 
-    @Operation(summary = "인증 번호 발급 메서드")
+    @Operation(summary = "인증 번호 발급 메서드", description = "비밀 번호 재설정을 위한 본인 인증 번호를 이메일로 발급합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created : 인증 번호 발급 후 전송 완료"),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
                     content = @Content(schema = @Schema(implementation=Void.class)))
     })
-    @Parameter(name = "회원 이메일", description = "인증 번호를 발급할 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
     @PostMapping("/password/certification")
-    ResponseEntity issueCertificationNumber(@RequestParam @Email String email){
+    ResponseEntity<Void> issueCertificationNumber(
+            @Parameter(description = "인증 번호를 발급할 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
+            @RequestParam @Email String email){
         searchMemberService.issueCertificationNumber(email);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @Operation(summary = "인증 번호 확인 메서드")
+    @Operation(summary = "인증 번호 확인 메서드", description = "비밀 번호 재설정을 위해 전송된 인증 번호를 확인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 인증 성공"),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Parameter(name = "회원 이메일", description = "인증 번호를 발급한 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
-    @Parameter(name = "인증 번호", description = "발급받은 인증 번호", example = "4865", required = true)
     @GetMapping("/password/certification")
-    ResponseEntity checkCertificationNumber(@RequestParam @Email String email, @RequestParam int code){
+    ResponseEntity<Void> checkCertificationNumber(
+            @Parameter(description = "인증 번호를 발급한 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
+            @RequestParam @Email String email,
+            @Parameter(description = "발급받은 인증 번호", example = "4865", required = true)
+            @RequestParam int code){
         searchMemberService.checkCertificationNumber(email, code);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "인증 여부 확인 메서드")
+    @Operation(summary = "인증 여부 확인 메서드", description = "비밀번호 재설정을 위한 본인 인증 여부를 확인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 인증 여부 확인됨"),
             @ApiResponse(responseCode = "400", description = "Bad Request : 닉네임이 일치하지 않음",
-                    content = @Content(schema = @Schema(implementation=Void.class))),
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @Parameter(name = "회원 이메일", description = "회원 정보 확인을 위한 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
-    @Parameter(name = "회원 닉네임", description = "회원 정보 확인을 위한 닉네임", example = "kimLeeChoi21", required = true)
     @GetMapping("/password")
-    ResponseEntity checkCertificationStatus(@RequestParam @Email String email, @RequestParam String nickname){
+    ResponseEntity<Void> checkCertificationStatus(
+            @Parameter(description = "회원 정보 확인을 위한 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
+            @RequestParam @Email String email,
+            @Parameter(description = "회원 정보 확인을 위한 닉네임", example = "kimLeeChoi21", required = true)
+            @RequestParam String nickname){
         searchMemberService.checkCertificationStatus(nickname, email);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "비밀번호 재설정 메서드")
+    @Operation(summary = "비밀번호 재설정 메서드", description = "새로운 비밀번호를 입력받아 재설정 합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Ok : 비밀번호 변경 성공"),
             @ApiResponse(responseCode = "401", description = "Unauthorized : 이메일 인증 필요",
-                    content = @Content(schema = @Schema(implementation=Void.class))),
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
-                    content = @Content(schema = @Schema(implementation=Void.class)))
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
     @PatchMapping("/password")
-    ResponseEntity updatePassword(@RequestBody PasswordUpdateDto passwordUpdateDto){
+    ResponseEntity<Void> updatePassword(@RequestBody PasswordUpdateDto passwordUpdateDto){
         searchMemberService.updatePassword(passwordUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberJoinDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberJoinDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Schema(title = "MemberRequest : 일반 회원 가입 DTO")
 @Getter
 public class MemberJoinDto {
-    @Schema(description = "사용할 email", example = "kimLeeChoi@mail.com")
+    @Schema(description = "사용할 email", example = "kimLeeChoi@prologmail.com")
     @Email
     private String email;
     @Schema(description = "사용할 password", example = "password1234")

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberUpdateDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberUpdateDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Schema(title = "MemberRequest : 회원 정보 수정 DTO")
 @Getter
 public class MemberUpdateDto {
-    @Schema(description = "회원 email. 변경을 원하는 경우 새로운 email이 담김", example = "kimLeeChoi@mail.com")
+    @Schema(description = "회원 email. 변경을 원하는 경우 새로운 email이 담김", example = "kimLeeChoi@prologmail.com")
     @Email
     private String email;
     @Schema(description = "회원 password. 변경을 원하는 경우 새로운 password가 담김", example = "password1234")

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Request/PasswordUpdateDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Request/PasswordUpdateDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Schema(title = "MemberRequest : 비밀번호 재발급 DTO")
 @Getter
 public class PasswordUpdateDto {
-    @Schema(description = "정보 확인에 사용될 email", example = "kimLeeChoi@mail.com")
+    @Schema(description = "정보 확인에 사용될 email", example = "kimLeeChoi@prologmail.com")
     @Email
     private String email;
     @Schema(description = "회원의 새로운 password", example = "password1234")

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Response/SimpleMemberDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Response/SimpleMemberDto.java
@@ -11,7 +11,7 @@ public class SimpleMemberDto {
     private String nickName;
     @Schema(description = "회원 프로필 이미지 링크", example = "profileImageS3Link")
     private String profileImage;
-    @Schema(description = "회원 email", example = "kimLeeChoi@mail.com")
+    @Schema(description = "회원 email", example = "kimLeeChoi@prologmail.com")
     private String email;
     @Schema(description = "회원 phone number", example = "010-1234-5678")
     private String phone;

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
@@ -36,7 +36,7 @@ public class TeamMemberController {
                     content = @Content(schema = @Schema(implementation=Void.class)))
     })
     @PostMapping("/teamMembers")
-    public ResponseEntity createTeamMember(@Valid @RequestBody CreateTeamMemberDto createTeamMemberDto){
+    public ResponseEntity<Void> createTeamMember(@Valid @RequestBody CreateTeamMemberDto createTeamMemberDto){
         Project project = projectService.getProject(createTeamMemberDto.getProjectId());
         Member member = memberService.getMember(createTeamMemberDto.getMemberId());
         teamMemberService.createTeamMember(project, member, createTeamMemberDto.getParts());
@@ -51,10 +51,11 @@ public class TeamMemberController {
             @ApiResponse(responseCode = "404", description = "Not Found : 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation=Void.class)))
     })
-    @Schema(description = "Path Variable. 삭제할 팀멤버 id", example = "2")
     @DeleteMapping("/api/teamMembers/{team-id}")
-    public ResponseEntity removeTeamMember(@AuthenticationPrincipal Member member,
-                                           @PathVariable("team-id") Long teamId){
+    public ResponseEntity<Void> removeTeamMember(
+            @AuthenticationPrincipal Member member,
+            @Schema(description = "Path Variable. 삭제할 팀멤버 id", example = "2")
+            @PathVariable("team-id") Long teamId){
         teamMemberService.removeTeamMember(member, teamId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
@@ -49,18 +49,10 @@ public class TeamMemberService {
      */
     @Transactional
     public void removeTeamMember(Member member, Long teamId){
-        TeamMember teamMember = teamMemberRepository.findById(teamId).orElseThrow(() -> {
-            throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND);
-        });
+        TeamMember teamMember = getEntityById(teamId);
 
         if(teamMember.getMember().getId() != member.getId()) {
-            String part = teamMemberRepository.findByMemberAndProject(member, teamMember.getProject())
-                    .orElseThrow(() -> {
-                        throw new BusinessLogicException(TeamMemberExceptionType.FORBIDDEN);
-                    }).getPart();
-
-            if (!Arrays.stream(part.split(",")).toList().contains(Part.Leader.toString()))
-                throw new BusinessLogicException(TeamMemberExceptionType.FORBIDDEN);
+            getEntityByMemberAndProject(member, teamMember.getProject());
         }
 
         teamMemberRepository.delete(teamMember);
@@ -102,16 +94,31 @@ public class TeamMemberService {
     }
 
     /**
-     * 특정 회원의 특정 프로젝트와 일치하는 팀멤버 엔티티를 반환
+     * 특정 회원의 특정 프로젝트와 일치하는 팀멤버 엔티티 조회
      * : 특정 회원의 일지 목록 조회 시 호출
      *
      * @param member : 회원 기준으로 팀멤버 조회
      * @param project : 프로젝트 기준으로 팀멤버 조회
-     * @return : 조회된 팀멤버 엔티티의 목록 반환
      */
-    public TeamMember getEntityByMemberAndProject(Member member, Project project){
-        return teamMemberRepository.findByMemberAndProject(member, project).orElseThrow(
-                () -> { throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND); }
-        );
+    public void getEntityByMemberAndProject(Member member, Project project){
+        String part = teamMemberRepository.findByMemberAndProject(member, project)
+                .orElseThrow(() -> {
+                    throw new BusinessLogicException(TeamMemberExceptionType.FORBIDDEN);
+                }).getPart();
+
+        if (!Arrays.stream(part.split(",")).toList().contains(Part.Leader.toString()))
+            throw new BusinessLogicException(TeamMemberExceptionType.FORBIDDEN);
+    }
+
+    /**
+     * 팀멤버 ID로 엔티티 조회
+     *
+     * @param teamMemberId : 조회할 팀멤버 id
+     * @return : 조회된 팀멤버 엔티티 반환
+     */
+    public TeamMember getEntityById(Long teamMemberId){
+        return teamMemberRepository.findById(teamMemberId).orElseThrow(() -> {
+            throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND);
+        });
     }
 }


### PR DESCRIPTION
## 🔗관련 이슈
* resolve : #50 
## 📑세부 내용
* **기능 추가**
  * 추가 기능 문서화 설정
  * 팀멤버 id로 엔티티 조회 메서드
* **기능 수정**
  * Response 형식 수정
  * 스웨거 parameter 설정 위치 변경
  * 프로젝트 및 멤버로 조회 시 역할 확인 과정 추가, 반환 타입 void로 수정
## ✍️추가 설명
* 프로젝트랑 멤버로 팀멤버 조회하는 경우에 역할이 Leader인지 확인하는 과정이 뒤에 꼭 붙더라구요!
  * 그래서 팀멤버 메서드 내에서 해당 과정까지 체크하도록 했구요,
  * 그 이후에 팀멤버 엔티티를 이용하는 작업은 없는 것 같아서 반환 타입은 void로 수정했습니다
* 스웨거 설정에서 에러 반환 클래스 타입을 void가 아닌 ErrorResponse로 수정하였습니다
  * 저희가 예외 처리한 후 응답에 ErrorResponse를 담아서 전송하다 보니 문서에도 반영하면 좋을 것 같다 생각했습니다..!