### PR TITLE
담당 기능 수정 및 서비스 클래스 분리 

### DIFF
--- a/src/main/java/com/prolog/prologbackend/Config/SpringSecurityConfig.java
+++ b/src/main/java/com/prolog/prologbackend/Config/SpringSecurityConfig.java
@@ -20,6 +20,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
@@ -36,6 +40,7 @@ public class SpringSecurityConfig {
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.formLogin(AbstractHttpConfigurer::disable)
+                .cors(corsConfig -> corsConfig.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement ->
@@ -52,12 +57,22 @@ public class SpringSecurityConfig {
         return http.build();
     }
 
+    CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedHeaders(Collections.singletonList("*"));
+            config.setAllowedMethods(Collections.singletonList("*"));
+            config.setAllowedOriginPatterns(Collections.singletonList("*"));
+            config.setAllowCredentials(true);
+            return config;
+        };
+    }
+
     @Bean
     PasswordEncoder setPasswordEncoder(){
         return new BCryptPasswordEncoder();
     }
 
-    @Bean
     public CustomAuthenticationFilter customAuthenticationFilter() throws Exception {
         CustomAuthenticationFilter customAuthenticationFilter =
                 new CustomAuthenticationFilter(authenticationConfiguration.getAuthenticationManager(),jwtProvider);
@@ -65,14 +80,12 @@ public class SpringSecurityConfig {
         return customAuthenticationFilter;
     }
 
-    @Bean
     public CustomAuthorizationFilter customAuthorizationFilter() {
         CustomAuthorizationFilter customAuthorizationFilter =
                 new CustomAuthorizationFilter(jwtProvider,customUserDetailsService);
         return customAuthorizationFilter;
     }
 
-    @Bean
     public CustomLogoutFilter customLogoutFilter() {
         CustomLogoutFilter customLogoutFilter =
                 new CustomLogoutFilter(customLogoutSuccessHandler, customLogoutHandler, jwtProvider);

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
@@ -28,6 +28,19 @@ import org.springframework.web.bind.annotation.*;
 public class AnyMemberController {
     private final AnyMemberService anyMemberService;
 
+    @Operation(summary = "팀원 조회", description = "초대를 원하는 팀원의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok : 팀원 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "Not Found : 존재하지 않는 멤버",
+                    content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
+    })
+    @GetMapping("/email")
+    ResponseEntity findMemberByEmail(
+            @Parameter(description = "초대하려는 팀원의 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
+            @RequestParam @Email String email){
+        return ResponseEntity.status(HttpStatus.OK).body(anyMemberService.getMemberByEmail(email));
+    }
+
     @Operation(summary = "일반 회원 가입 메서드", description = "일반 회원 가입을 통해 회원을 등록합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created : 일반 회원가입 성공"),
@@ -41,9 +54,7 @@ public class AnyMemberController {
     }
 
     @Operation(summary = "카카오 소셜 회원가입 및 로그인", description = "카카오 소셜 로그인을 통해 회원 등록 및 로그인 합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Created : 소셜 로그인 성공")
-    })
+    @ApiResponse(responseCode = "201", description = "Created : 소셜 로그인 성공")
     @PostMapping("/login/oauth/kakao")
     ResponseEntity<Void> socialLoginMember(
             @Parameter(description = "카카오 서버 인증에 필요한 코드", example = "kakaoCodeKakaoCode", required = true)
@@ -60,7 +71,7 @@ public class AnyMemberController {
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 사용중인 이메일",
                     content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @GetMapping("/email")
+    @GetMapping("/validation/email")
     ResponseEntity<Void> validateEmail(
             @Parameter(description = "사용중인지 확인하고 싶은 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
             @RequestParam @Email String email){
@@ -76,7 +87,7 @@ public class AnyMemberController {
             @ApiResponse(responseCode = "409", description = "Conflict : 이미 사용중인 닉네임",
                     content = @Content(schema = @Schema(implementation=ErrorResponse.class)))
     })
-    @GetMapping("/nickname")
+    @GetMapping("/validation/nickname")
     ResponseEntity<Void> validateNickname(
             @Parameter(description = "사용중인지 확인하고 싶은 닉네임", example = "kimLeeChoi21", required = true)
             @RequestParam @NotBlank @Size(max=20, message="닉네임은 20자 미만으로 작성해야 합니다.") String nickname) {

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/AnyMemberController.java
@@ -2,7 +2,7 @@ package com.prolog.prologbackend.Member.Controller;
 
 import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.MemberJoinDto;
-import com.prolog.prologbackend.Member.Service.AnyMemberService;
+import com.prolog.prologbackend.Member.Service.Facade.AnyMemberFacadeService;
 import com.prolog.prologbackend.Security.Jwt.JwtType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class AnyMemberController {
-    private final AnyMemberService anyMemberService;
+    private final AnyMemberFacadeService anyMemberFacadeService;
 
     @Operation(summary = "팀원 조회", description = "초대를 원하는 팀원의 정보를 조회합니다.")
     @ApiResponses(value = {
@@ -38,7 +38,7 @@ public class AnyMemberController {
     ResponseEntity findMemberByEmail(
             @Parameter(description = "초대하려는 팀원의 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
             @RequestParam @Email String email){
-        return ResponseEntity.status(HttpStatus.OK).body(anyMemberService.getMemberByEmail(email));
+        return ResponseEntity.status(HttpStatus.OK).body(anyMemberFacadeService.getMemberByEmail(email));
     }
 
     @Operation(summary = "일반 회원 가입 메서드", description = "일반 회원 가입을 통해 회원을 등록합니다.")
@@ -49,7 +49,7 @@ public class AnyMemberController {
     })
     @PostMapping("/signup")
     ResponseEntity<Void> joinMember(@Valid @RequestBody MemberJoinDto joinDto){
-        anyMemberService.joinMember(joinDto);
+        anyMemberFacadeService.joinMember(joinDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -59,7 +59,7 @@ public class AnyMemberController {
     ResponseEntity<Void> socialLoginMember(
             @Parameter(description = "카카오 서버 인증에 필요한 코드", example = "kakaoCodeKakaoCode", required = true)
             @RequestParam String code, HttpServletResponse response){
-        String[] tokens = anyMemberService.loginToKaKao(code);
+        String[] tokens = anyMemberFacadeService.loginToKaKao(code);
         response.addHeader(JwtType.ACCESS_TOKEN.getTokenType(),tokens[0]);
         response.addHeader(JwtType.REFRESH_TOKEN.getTokenType(),tokens[1]);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -75,7 +75,7 @@ public class AnyMemberController {
     ResponseEntity<Void> validateEmail(
             @Parameter(description = "사용중인지 확인하고 싶은 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
             @RequestParam @Email String email){
-        if (anyMemberService.validateEmail(email))
+        if (anyMemberFacadeService.validateEmail(email))
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         else
             return ResponseEntity.status(HttpStatus.OK).build();
@@ -91,7 +91,7 @@ public class AnyMemberController {
     ResponseEntity<Void> validateNickname(
             @Parameter(description = "사용중인지 확인하고 싶은 닉네임", example = "kimLeeChoi21", required = true)
             @RequestParam @NotBlank @Size(max=20, message="닉네임은 20자 미만으로 작성해야 합니다.") String nickname) {
-        if(anyMemberService.validateNickname(nickname))
+        if(anyMemberFacadeService.validateNickname(nickname))
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         else
             return ResponseEntity.status(HttpStatus.OK).build();
@@ -109,7 +109,7 @@ public class AnyMemberController {
     ResponseEntity<Void> verificationEmail(
             @Schema(description = "이메일 인증을 위해 발급받은 토큰", example = "verificationTokenVerificationEmailToken")
             @PathVariable String token){
-        anyMemberService.verificationEmail(token);
+        anyMemberFacadeService.verificationEmail(token);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
@@ -4,7 +4,7 @@ import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.MemberUpdateDto;
 import com.prolog.prologbackend.Member.DTO.Response.BasicMemberDto;
 import com.prolog.prologbackend.Member.Domain.Member;
-import com.prolog.prologbackend.Member.Service.MemberService;
+import com.prolog.prologbackend.Member.Service.Facade.MemberFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberService memberService;
+    private final MemberFacadeService memberFacadeService;
 
     @Operation(summary = "사용자 정보 조회 메서드", description = "로그인한 사용자의 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "Ok : 사용자 정보 조회 성공",
@@ -41,7 +41,7 @@ public class MemberController {
     @PatchMapping("/information")
     ResponseEntity<Void> updateMember(@AuthenticationPrincipal Member member,
                                 @RequestBody @Valid MemberUpdateDto dto){
-        memberService.updateMember(member.getEmail(), dto);
+        memberFacadeService.updateMember(member.getEmail(), dto);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -49,7 +49,7 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "Ok : 회원 탈퇴 성공")
     @DeleteMapping
     ResponseEntity<Void> withdrawMember(@AuthenticationPrincipal Member member){
-        memberService.deleteMember(member);
+        memberFacadeService.deleteMember(member);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -69,9 +69,9 @@ public class MemberController {
             @Parameter(description = "이미지 수정을 위해 새로 적용할 multipart/form-data 형식의 이미지 파일")
             @RequestPart(value = "image") MultipartFile image){
         if(image.isEmpty())
-            memberService.resetProfileImage(member.getEmail());
+            memberFacadeService.resetProfileImage(member.getEmail());
         else
-            memberService.updateProfileImage(member.getEmail(), image);
+            memberFacadeService.updateProfileImage(member.getEmail(), image);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/MemberController.java
@@ -2,7 +2,7 @@ package com.prolog.prologbackend.Member.Controller;
 
 import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.MemberUpdateDto;
-import com.prolog.prologbackend.Member.DTO.Response.SimpleMemberDto;
+import com.prolog.prologbackend.Member.DTO.Response.BasicMemberDto;
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,21 +29,15 @@ public class MemberController {
     private final MemberService memberService;
 
     @Operation(summary = "사용자 정보 조회 메서드", description = "로그인한 사용자의 정보를 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Ok : 사용자 정보 조회 성공",
-                    content = @Content(schema = @Schema(implementation=SimpleMemberDto.class)))
-    })
+    @ApiResponse(responseCode = "200", description = "Ok : 사용자 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation=BasicMemberDto.class)))
     @GetMapping("/information")
     ResponseEntity getMember(@AuthenticationPrincipal Member member){
-        return ResponseEntity.status(HttpStatus.OK).body(SimpleMemberDto.of(member));
+        return ResponseEntity.status(HttpStatus.OK).body(BasicMemberDto.of(member));
     }
 
     @Operation(summary = "회원 정보 수정 메서드", description = "사용자는 자신의 정보 중 일부 또는 전부를 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Ok : 정보 수정 성공"),
-            @ApiResponse(responseCode = "409", description = "Conflict : 변경하려는 이메일이 이미 사용중임",
-                    content = @Content(schema = @Schema(implementation= ErrorResponse.class)))
-    })
+    @ApiResponse(responseCode = "200", description = "Ok : 정보 수정 성공")
     @PatchMapping("/information")
     ResponseEntity<Void> updateMember(@AuthenticationPrincipal Member member,
                                 @RequestBody @Valid MemberUpdateDto dto){
@@ -52,9 +46,7 @@ public class MemberController {
     }
 
     @Operation(summary = "회원 탈퇴 메서드", description = "서비스 이용 중지를 위한 회원 탈퇴를 진행합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Ok : 회원 탈퇴 성공")
-    })
+    @ApiResponse(responseCode = "200", description = "Ok : 회원 탈퇴 성공")
     @DeleteMapping
     ResponseEntity<Void> withdrawMember(@AuthenticationPrincipal Member member){
         memberService.deleteMember(member);

--- a/src/main/java/com/prolog/prologbackend/Member/Controller/SearchMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Controller/SearchMemberController.java
@@ -2,7 +2,7 @@ package com.prolog.prologbackend.Member.Controller;
 
 import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Member.DTO.Request.PasswordUpdateDto;
-import com.prolog.prologbackend.Member.Service.SearchMemberService;
+import com.prolog.prologbackend.Member.Service.Facade.SearchMemberFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/search")
 @RequiredArgsConstructor
 public class SearchMemberController {
-    private final SearchMemberService searchMemberService;
+    private final SearchMemberFacadeService searchMemberFacadeService;
 
     @Operation(summary = "이메일 찾기 메서드", description = "사용자 정보를 이용하여 올바른 사용자에 한해 이메일을 조회합니다.")
     @ApiResponses(value = {
@@ -36,7 +36,7 @@ public class SearchMemberController {
             @RequestParam @NotBlank String nickname,
             @Parameter(description = "회원 정보 확인을 위한 핸드폰 번호", example = "010-1234-5678", required = true)
             @RequestParam @NotBlank String phone){
-        return ResponseEntity.status(HttpStatus.OK).body(searchMemberService.findEmail(nickname, phone));
+        return ResponseEntity.status(HttpStatus.OK).body(searchMemberFacadeService.findEmail(nickname, phone));
     }
 
     @Operation(summary = "인증 번호 발급 메서드", description = "비밀 번호 재설정을 위한 본인 인증 번호를 이메일로 발급합니다.")
@@ -49,7 +49,7 @@ public class SearchMemberController {
     ResponseEntity<Void> issueCertificationNumber(
             @Parameter(description = "인증 번호를 발급할 이메일 주소", example = "kimLeeChoi@mail.com", required = true)
             @RequestParam @Email String email){
-        searchMemberService.issueCertificationNumber(email);
+        searchMemberFacadeService.issueCertificationNumber(email);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -65,7 +65,7 @@ public class SearchMemberController {
             @RequestParam @Email String email,
             @Parameter(description = "발급받은 인증 번호", example = "4865", required = true)
             @RequestParam int code){
-        searchMemberService.checkCertificationNumber(email, code);
+        searchMemberFacadeService.checkCertificationNumber(email, code);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -83,7 +83,7 @@ public class SearchMemberController {
             @RequestParam @Email String email,
             @Parameter(description = "회원 정보 확인을 위한 닉네임", example = "kimLeeChoi21", required = true)
             @RequestParam String nickname){
-        searchMemberService.checkCertificationStatus(nickname, email);
+        searchMemberFacadeService.checkCertificationStatus(nickname, email);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
@@ -97,7 +97,7 @@ public class SearchMemberController {
     })
     @PatchMapping("/password")
     ResponseEntity<Void> updatePassword(@RequestBody PasswordUpdateDto passwordUpdateDto){
-        searchMemberService.updatePassword(passwordUpdateDto);
+        searchMemberFacadeService.updatePassword(passwordUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberUpdateDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Request/MemberUpdateDto.java
@@ -1,17 +1,14 @@
 package com.prolog.prologbackend.Member.DTO.Request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Schema(title = "MemberRequest : 회원 정보 수정 DTO")
 @Getter
 public class MemberUpdateDto {
-    @Schema(description = "회원 email. 변경을 원하는 경우 새로운 email이 담김", example = "kimLeeChoi@prologmail.com")
-    @Email
-    private String email;
     @Schema(description = "회원 password. 변경을 원하는 경우 새로운 password가 담김", example = "password1234")
     @NotBlank
     @Size(min=8, max=20, message="비밀번호는 최소 8자리, 최대 12자리로 작성해야 합니다.")
@@ -20,4 +17,8 @@ public class MemberUpdateDto {
     @NotBlank
     @Size(max=20, message="닉네임은 20자 미만으로 작성해야 합니다.")
     private String nickname;
+    @Schema(description = "사용할 phone number", example = "010-1234-5678")
+    @NotBlank
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호는 11자리 숫자와 '-'로 구성되어야 합니다.")
+    private String phone;
 }

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Response/BasicMemberDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Response/BasicMemberDto.java
@@ -4,25 +4,28 @@ import com.prolog.prologbackend.Member.Domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Schema(title = "MemberResponse : 초대할 팀원의 등록을 위한 정보 조회 DTO")
+@Schema(title = "MemberResponse : 로그인한 사용자 정보 조회 DTO")
 @Getter
-public class SimpleMemberDto {
-    @Schema(description = "회원 id", example = "2")
-    private Long id;
+public class BasicMemberDto {
     @Schema(description = "회원 닉네임", example = "개발새발")
     private String nickName;
     @Schema(description = "회원 프로필 이미지 링크", example = "profileImageS3Link")
     private String profileImage;
     @Schema(description = "회원 email", example = "kimLeeChoi@prologmail.com")
     private String email;
+    @Schema(description = "회원 phone number", example = "010-1234-5678")
+    private String phone;
+    @Schema(description = "일반 회원 여부", example = "true")
+    private boolean isBasic;
 
-    public static SimpleMemberDto of(Member member){
-        SimpleMemberDto memberDto = new SimpleMemberDto();
+    public static BasicMemberDto of(Member member){
+        BasicMemberDto memberDto = new BasicMemberDto();
 
-        memberDto.id = memberDto.getId();
         memberDto.nickName = member.getNickname();
         memberDto.profileImage = member.getProfileImage();
         memberDto.email = member.getEmail();
+        memberDto.phone = member.getPhone();
+        memberDto.isBasic = member.getStatus().isBasicMember();
 
         return memberDto;
     }

--- a/src/main/java/com/prolog/prologbackend/Member/DTO/Response/SimpleMemberDto.java
+++ b/src/main/java/com/prolog/prologbackend/Member/DTO/Response/SimpleMemberDto.java
@@ -19,7 +19,7 @@ public class SimpleMemberDto {
     public static SimpleMemberDto of(Member member){
         SimpleMemberDto memberDto = new SimpleMemberDto();
 
-        memberDto.id = memberDto.getId();
+        memberDto.id = member.getId();
         memberDto.nickName = member.getNickname();
         memberDto.profileImage = member.getProfileImage();
         memberDto.email = member.getEmail();

--- a/src/main/java/com/prolog/prologbackend/Member/Domain/Member.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Domain/Member.java
@@ -68,18 +68,16 @@ public class Member extends BaseTimeEntity{
         return new ArrayList<>();
     }
 
-    public void updateEmail(String email){
-        if(!this.email.equals(email))
-            this.email = email;
-    }
-
     public void updatePassword(String password){
         this.password = password;
     }
 
     public void updateNickname(String nickname){
-        if(!this.nickname.equals(nickname))
-            this.nickname = nickname;
+        if(!this.nickname.equals(nickname)) this.nickname = nickname;
+    }
+
+    public void updatePhoneNumber(String phone){
+        if(!this.phone.equals(phone)) this.phone = phone;
     }
 
     public void setVerified(){

--- a/src/main/java/com/prolog/prologbackend/Member/Domain/Member.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Domain/Member.java
@@ -73,11 +73,12 @@ public class Member extends BaseTimeEntity{
     }
 
     public void updateNickname(String nickname){
-        if(!this.nickname.equals(nickname)) this.nickname = nickname;
+        this.nickname = nickname;
     }
 
     public void updatePhoneNumber(String phone){
-        if(!this.phone.equals(phone)) this.phone = phone;
+        if(!this.phone.equals(phone))
+            this.phone = phone;
     }
 
     public void setVerified(){

--- a/src/main/java/com/prolog/prologbackend/Member/ExceptionType/MemberExceptionType.java
+++ b/src/main/java/com/prolog/prologbackend/Member/ExceptionType/MemberExceptionType.java
@@ -6,6 +6,7 @@ public enum MemberExceptionType implements ExceptionType {
     BAD_REQUEST(400,"잘못된 회원 정보입니다"),
     NOT_FOUND(404,"존재하지 않는 회원입니다"),
     CONFLICT(409,"이미 존재하는 회원입니다"),
+    LOCKED(423,"탈퇴한 회원입니다."),
     INTERNAL_SERVER_ERROR(500,"요청 처리에 실패했습니다 다시 시도해주세요"),
     //회원 정보 찾기
     CODE_BAD_REQUEST(400, "잘못된 인증번호 입니다"),

--- a/src/main/java/com/prolog/prologbackend/Member/Repository/MemberRepository.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Repository/MemberRepository.java
@@ -6,11 +6,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByNicknameAndIsDeletedFalse(String nickname);
+    List<Member> findAllByIsDeletedTrueAndModifiedDateBefore(LocalDateTime date);
     @Modifying
     @Query("update member m set m.isDeleted = true, m.modifiedDate = ?1 where m.id = ?2")
     void updateMemberStatus(LocalDateTime updateDate, Long memberId);

--- a/src/main/java/com/prolog/prologbackend/Member/Repository/MemberRepository.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Repository/MemberRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmailAndIsDeletedFalse(String email);
     Optional<Member> findByNicknameAndIsDeletedFalse(String nickname);
     List<Member> findAllByIsDeletedTrueAndModifiedDateBefore(LocalDateTime date);
     @Modifying

--- a/src/main/java/com/prolog/prologbackend/Member/Repository/SearchRedisRepository.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Repository/SearchRedisRepository.java
@@ -24,14 +24,15 @@ public class SearchRedisRepository {
     }
 
     public void validateCertificationNumberByEmail(String user, String code){
-        String codeInRedis = redisTemplate.opsForValue().get("Certification:"+user).toString();
+        Object codeInRedis = redisTemplate.opsForValue().get("Certification:"+user);
         if(Objects.isNull(codeInRedis))
             throw new BusinessLogicException(MemberExceptionType.CODE_NOT_FOUND);
-        if(!code.equals(codeInRedis))
+        if(!code.equals(codeInRedis.toString()))
             throw new BusinessLogicException(MemberExceptionType.CODE_BAD_REQUEST);
     }
 
-    public boolean findCertificationStatus(String user){
-        return redisTemplate.hasKey("Password:"+user).booleanValue();
+    public void checkCertificationStatus(String email){
+        if(!redisTemplate.hasKey("Password:"+email).booleanValue())
+                    throw new BusinessLogicException(MemberExceptionType.CODE_UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/Service/AnyMemberService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/AnyMemberService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prolog.prologbackend.Exception.BusinessLogicException;
 import com.prolog.prologbackend.Member.DTO.Request.KaKaoInfoDto;
 import com.prolog.prologbackend.Member.DTO.Request.MemberJoinDto;
+import com.prolog.prologbackend.Member.DTO.Response.SimpleMemberDto;
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Domain.MemberStatus;
 import com.prolog.prologbackend.Member.ExceptionType.MemberExceptionType;
@@ -197,6 +198,18 @@ public class AnyMemberService {
         member.setVerified();
     }
 
+    /**
+     * 초대할 팀원의 정보 조회
+     * : 토큰을 확인하여 회원의 이메일 인증을 진행
+     *
+     * @param email : 조회할 팀원의 email
+     * @throws : 이미 인증한 경우 에러 발생 (409)
+     */
+    public SimpleMemberDto getMemberByEmail(String email){
+        Member member = memberRepository.findByNicknameAndIsDeletedFalse(email)
+                .orElseThrow(() -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
+        return SimpleMemberDto.of(member);
+    }
 
     private String getKakaoToken(String code){
         RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/prolog/prologbackend/Member/Service/Facade/AnyMemberFacadeService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/Facade/AnyMemberFacadeService.java
@@ -1,7 +1,5 @@
-package com.prolog.prologbackend.Member.Service;
+package com.prolog.prologbackend.Member.Service.Facade;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.prolog.prologbackend.Exception.BusinessLogicException;
 import com.prolog.prologbackend.Member.DTO.Request.KaKaoInfoDto;
 import com.prolog.prologbackend.Member.DTO.Request.MemberJoinDto;
@@ -9,47 +7,30 @@ import com.prolog.prologbackend.Member.DTO.Response.SimpleMemberDto;
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Domain.MemberStatus;
 import com.prolog.prologbackend.Member.ExceptionType.MemberExceptionType;
-import com.prolog.prologbackend.Member.Repository.MemberRepository;
+import com.prolog.prologbackend.Member.Service.Other.KakaoService;
+import com.prolog.prologbackend.Member.Service.MemberService;
+import com.prolog.prologbackend.Member.Service.Other.MailService;
 import com.prolog.prologbackend.Security.Jwt.JwtProvider;
 import com.prolog.prologbackend.Security.Jwt.JwtType;
 import io.jsonwebtoken.Claims;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-public class AnyMemberService {
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
+public class AnyMemberFacadeService {
+    private final MemberService memberService;
+    private final MailService mailService;
+    private final KakaoService kakaoService;
     private final JwtProvider jwtProvider;
-    private final String CONTENT_TYPE = "application/x-www-form-urlencoded;charset=utf-8";
-    private final JavaMailSender javaMailSender;
-    private final TemplateEngine templateEngine;
-    @Value("${kakao.id}")
-    private String CLIENT_ID;
-    @Value("${kakao.uri}")
-    private String REDIRECT_URI;
-    @Value("${url.verification}")
-    private String VERIFICATION_URL;
-    @Value("${url.profileImage}")
+    private final PasswordEncoder passwordEncoder;
+    @Value("${image.profileImage}")
     private String PROFILE_IMAGE_URL;
 
 
@@ -63,15 +44,13 @@ public class AnyMemberService {
      */
     @Transactional
     public void joinMember(MemberJoinDto joinDto){
-        Optional<Member> getMember = memberRepository.findByEmail(joinDto.getEmail());
-        Member newMember;
-        if(getMember.isPresent()){
-            if(getMember.get().getStatus().isBasicMember())
+        Member getMember = memberService.getMemberByEmail(joinDto.getEmail());
+        if(getMember != null){
+            if(getMember.getStatus().isBasicMember())
                 throw new BusinessLogicException(MemberExceptionType.CONFLICT);
-            newMember = getMember.get();
-            newMember.joinToBasic(passwordEncoder.encode(joinDto.getPassword()), joinDto.getPhone());
+            getMember.joinToBasic(passwordEncoder.encode(joinDto.getPassword()), joinDto.getPhone());
         } else {
-            newMember = Member.builder()
+            getMember = Member.builder()
                     .email(joinDto.getEmail())
                     .password(passwordEncoder.encode(joinDto.getPassword()))
                     .phone(joinDto.getPhone())
@@ -83,29 +62,18 @@ public class AnyMemberService {
                     .profileImage(PROFILE_IMAGE_URL)
                     .roles("ROLE_USER")
                     .build();
-            memberRepository.save(newMember);
+            memberService.createMember(getMember);
         }
 
         String token = jwtProvider.createToken(JwtType.EMAIL_VERIFICATION, joinDto.getEmail());
 
-        Context context = new Context();
-        context.setVariable("link",VERIFICATION_URL+token);
-
         try {
-            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-
-            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setFrom("mailaddress@gmail.com");
-            mimeMessageHelper.setTo(joinDto.getEmail());
-            mimeMessageHelper.setSubject("[prolog] 이메일 인증");
-            mimeMessageHelper.setText(templateEngine.process("verificationEmail", context), true);
-
-            javaMailSender.send(mimeMessage);
+            mailService.sendVerificationEmail(joinDto.getEmail(), token);
         } catch (MessagingException e){
-            if(newMember.getStatus().isSocialMember())
-                newMember.resetJoinToBasic();
+            if(getMember.getStatus().isSocialMember())
+                getMember.resetJoinToBasic();
             else
-                memberRepository.delete(newMember);
+                memberService.deleteMember(getMember);
             throw new BusinessLogicException(MemberExceptionType.INTERNAL_SERVER_ERROR);
         }
     }
@@ -121,15 +89,15 @@ public class AnyMemberService {
      */
     @Transactional
     public String[] loginToKaKao(String code){
-        String kakaoToken = getKakaoToken(code);
+        String kakaoToken = kakaoService.getKakaoToken(code);
 
-        KaKaoInfoDto infos = getKakaoInfo("Bearer "+kakaoToken);
+        KaKaoInfoDto infos = kakaoService.getKakaoInfo("Bearer "+kakaoToken);
 
         String email =  infos.getKakao_account().getEmail();
         String nickname = infos.getKakao_account().getProfile().getNickname();
 
-        Optional<Member> getMember = memberRepository.findByEmail(email);
-        if(!getMember.isPresent()){
+        Member getMember = memberService.getMemberByEmail(email);
+        if(getMember == null){
             Member newMember = Member.builder()
                     .email(email)
                     .nickname(nickname)
@@ -141,9 +109,9 @@ public class AnyMemberService {
                     .roles("ROLE_USER")
                     .build();
 
-            memberRepository.save(newMember);
-        } else if(!getMember.get().getStatus().isSocialMember()) {
-            getMember.get().joinToSocial();
+            memberService.createMember(newMember);
+        } else if(!getMember.getStatus().isSocialMember()) {
+            getMember.joinToSocial();
         }
 
         String accessToken = jwtProvider.createToken(JwtType.ACCESS_TOKEN,email);
@@ -164,7 +132,7 @@ public class AnyMemberService {
      * @throws : 이미 존재하는 이메일의 경우 에러 발생 (409)
      */
     public boolean validateEmail(String email){
-        return memberRepository.findByEmail(email).isPresent();
+        return memberService.isPresentMemberByEmail(email);
     }
 
     /**
@@ -176,7 +144,7 @@ public class AnyMemberService {
      * @throws : 이미 존재하는 이메일의 경우 에러 발생 (409)
      */
     public boolean validateNickname(String nickname){
-        return memberRepository.findByNickname(nickname).isPresent();
+        return memberService.isPresentMemberByNickname(nickname);
     }
 
     /**
@@ -191,8 +159,7 @@ public class AnyMemberService {
         Claims claims = jwtProvider.parseToken(token);
         jwtProvider.verifyType(JwtType.EMAIL_VERIFICATION, claims);
         String email = jwtProvider.getEmail(claims);
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
+        Member member = memberService.getNotDeletedMemberByEmail(email);
         if(member.isVerified())
             throw new BusinessLogicException(MemberExceptionType.VERIFICATION_CONFLICT);
         member.setVerified();
@@ -206,51 +173,7 @@ public class AnyMemberService {
      * @throws : 이미 인증한 경우 에러 발생 (409)
      */
     public SimpleMemberDto getMemberByEmail(String email){
-        Member member = memberRepository.findByNicknameAndIsDeletedFalse(email)
-                .orElseThrow(() -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
+        Member member = memberService.getNotDeletedMemberByEmail(email);
         return SimpleMemberDto.of(member);
-    }
-
-    private String getKakaoToken(String code){
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", CONTENT_TYPE);
-
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", CLIENT_ID);
-        body.add("redirect_uri", REDIRECT_URI);
-        body.add("code", code);
-
-        HttpEntity entity = new HttpEntity(body, headers);
-        String requestUrl = "https://kauth.kakao.com/oauth/token";
-
-        ResponseEntity<Map> response =
-                restTemplate.exchange(requestUrl, HttpMethod.POST,entity, Map.class);
-
-        return response.getBody().get("access_token").toString();
-    }
-
-    private KaKaoInfoDto getKakaoInfo(String kakaoToken){
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", CONTENT_TYPE);
-        headers.add("Authorization", kakaoToken);
-
-        HttpEntity sec_entity = new HttpEntity(headers);
-        String requestUrl = "https://kapi.kakao.com/v2/user/me";
-
-        ResponseEntity<String> sec_response =
-                restTemplate.exchange(requestUrl,HttpMethod.POST,sec_entity, String.class);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        KaKaoInfoDto responseBody = null;
-        try {
-            responseBody = objectMapper.readValue(sec_response.getBody(), KaKaoInfoDto.class);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-
-        return responseBody;
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/Service/Facade/MemberFacadeService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/Facade/MemberFacadeService.java
@@ -1,0 +1,115 @@
+package com.prolog.prologbackend.Member.Service.Facade;
+
+import com.prolog.prologbackend.Exception.BusinessLogicException;
+import com.prolog.prologbackend.Member.DTO.Request.MemberUpdateDto;
+import com.prolog.prologbackend.Member.Domain.Member;
+import com.prolog.prologbackend.Member.ExceptionType.MemberExceptionType;
+import com.prolog.prologbackend.Member.Service.Other.ImageService;
+import com.prolog.prologbackend.Member.Service.MemberService;
+import com.prolog.prologbackend.Notes.Service.NotesService;
+import com.prolog.prologbackend.Project.Service.ProjectService;
+import com.prolog.prologbackend.TeamMember.Domain.TeamMember;
+import com.prolog.prologbackend.TeamMember.Service.TeamMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberFacadeService {
+    private final MemberService memberService;
+    private final TeamMemberService teamMemberService;
+    private final ProjectService projectService;
+    private final NotesService notesService;
+    private final ImageService imageService;
+    private final PasswordEncoder passwordEncoder;
+    @Value("${image.profileImage}")
+    private String PROFILE_IMAGE_URL;
+
+
+    /**
+     * 회원 정보 수정
+     * : 이메일, 비밀번호, 사용자명을 받아 현재 값과 비교하고 수정
+     *
+     * @param email : 요청 보낸 사용자의 이메일
+     * @param dto : 요청 시 받은 변경을 원하는 사용자의 정보
+     * @throws : 변경을 원하는 이메일이 이미 사용중인 경우 에러 발생 (409)
+     */
+    @Transactional
+    public void updateMember(String email, MemberUpdateDto dto){
+        Member member = memberService.getMemberByEmailWithoutThrowingException(email);
+
+        if(!member.getNickname().equals(dto.getNickname())){
+            if(!memberService.isPresentMemberByNickname(dto.getNickname()))
+                member.updateNickname(dto.getNickname());
+        }
+        if(!passwordEncoder.matches(dto.getPassword(),member.getPassword())) {
+            String encodePassword = passwordEncoder.encode(dto.getPassword());
+            member.updatePassword(encodePassword);
+        }
+        member.updatePhoneNumber(dto.getPhone());
+    }
+
+    /**
+     * 회원 탈퇴
+     * : 회원 및 프로젝트 상태 변경
+     * : 관련된 팀멤버 및 노트 엔티티 모두 삭제
+     *
+     * @param member : 요청 보낸 (탈퇴를 진행할) 사용자의 정보
+     */
+    @Transactional
+    public void deleteMember(Member member){
+        List<TeamMember> teamMembers = teamMemberService.getListByMember(member);
+
+        List<Long> projectIds = teamMembers.stream().filter(t -> t.getPart().contains("Leader"))
+                .map(t -> t.getProject().getProjectId()).toList();
+        for(Long projectId : projectIds){
+            projectService.deleteProject(projectId,member);
+        }
+
+        List<Long> teamMembersIds = teamMembers.stream().map(t -> t.getId()).toList();
+        notesService.deleteImageAndNotes(teamMembersIds);
+        teamMemberService.deleteTeamMemberByIds(teamMembersIds);
+
+        memberService.updateMemberStatus(member.getId());
+    }
+
+    /**
+     * 이미지 변경
+     * : 기존 이미지를 삭제하고 새 이미지로 설정
+     *
+     * @param email : 요청 보낸 사용자의 이메일
+     * @param multipartFile : 변경할 이미지 파일
+     */
+    @Transactional
+    public void updateProfileImage(String email, MultipartFile multipartFile){
+        Member member = memberService.getMemberByEmailWithoutThrowingException(email);
+
+        if(!member.isBasicImage() && !member.getProfileName().isBlank())
+            imageService.deleteProfileImage(member.getProfileName());
+
+        String fileName = imageService.createProfileImage(multipartFile);
+        String imageUrl = imageService.getImageUrl(fileName);
+        member.updateProfile(imageUrl, fileName);
+    }
+
+    /**
+     * 이미지 초기화
+     * : 기존 이미지를 삭제한 후 기본 이미지로 설정
+     *
+     * @param email : 요청 보낸 사용자의 이메일
+     */
+    @Transactional
+    public void resetProfileImage(String email) {
+        Member member = memberService.getMemberByEmailWithoutThrowingException(email);
+        if(member.isBasicImage())
+            throw new BusinessLogicException(MemberExceptionType.IMAGE_CONFLICT);
+        imageService.deleteProfileImage(member.getProfileName());
+        member.updateProfile(PROFILE_IMAGE_URL,null);
+    }
+}

--- a/src/main/java/com/prolog/prologbackend/Member/Service/MemberService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/MemberService.java
@@ -1,24 +1,12 @@
 package com.prolog.prologbackend.Member.Service;
 
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.prolog.prologbackend.Exception.BusinessLogicException;
-import com.prolog.prologbackend.Member.DTO.Request.MemberUpdateDto;
 import com.prolog.prologbackend.Member.ExceptionType.MemberExceptionType;
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Repository.MemberRepository;
-import com.prolog.prologbackend.Notes.Service.NotesService;
-import com.prolog.prologbackend.Project.Service.ProjectService;
-import com.prolog.prologbackend.TeamMember.Domain.TeamMember;
-import com.prolog.prologbackend.TeamMember.Service.TeamMemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -26,138 +14,77 @@ import java.util.*;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final TeamMemberService teamMemberService;
-    private final ProjectService projectService;
-    private final NotesService notesService;
-    private final AmazonS3Client amazonS3Client;
-    @Value("${S3Bucket}")
-    private String BUCKET;
-    @Value("${BasicImageUrl}")
-    private String IMAGE_URL;
 
 
-    /**
-     * 회원 정보 수정
-     * : 이메일, 비밀번호, 사용자명을 받아 현재 값과 비교하고 수정
-     *
-     * @param  : 요청 보낸 사용자의 이메일
-     * @param dto : 요청 시 받은 변경을 원하는 사용자의 정보
-     * @throws : 변경을 원하는 이메일이 이미 사용중인 경우 에러 발생 (409)
-     */
-    @Transactional
-    public void updateMember(String email, MemberUpdateDto dto){
-        Member member = memberRepository.findByEmail(email).get();
-
-        member.updateNickname(dto.getNickname());
-        member.updatePhoneNumber(dto.getPhone());
-        if(!passwordEncoder.matches(dto.getPassword(),member.getPassword())) {
-            String encodePassword = passwordEncoder.encode(dto.getPassword());
-            member.updatePassword(encodePassword);
-        }
+    //멤버 저장
+    public void createMember(Member member){
+        memberRepository.save(member);
     }
 
-    public Member getMemberById(Long id){
-        return memberRepository.findById(id).get();
-    }
-
-    /**
-     * 회원 탈퇴
-     * : 회원 및 프로젝트 상태 변경
-     * : 관련된 팀멤버 및 노트 엔티티 모두 삭제
-     *
-     * @param member : 요청 보낸 (탈퇴를 진행할) 사용자의 정보
-     */
-    @Transactional
-    public void deleteMember(Member member){
-        List<TeamMember> teamMembers = teamMemberService.getListByMember(member);
-
-        List<Long> projectIds = teamMembers.stream().filter(t -> t.getPart().contains("Leader"))
-                        .map(t -> t.getProject().getProjectId()).toList();
-        for(Long projectId : projectIds){
-            projectService.deleteProject(projectId,member);
-        }
-
-        List<Long> teamMembersIds = teamMembers.stream().map(t -> t.getId()).toList();
-        notesService.deleteImageAndNotes(teamMembersIds);
-        teamMemberService.deleteTeamMemberByIds(teamMembersIds);
-
+    //멤버 탈퇴 상태로 수정 : Id
+    public void updateMemberStatus(Long id){
         LocalDateTime updateDate = LocalDateTime.now();
-        memberRepository.updateMemberStatus(updateDate, member.getId());
+        memberRepository.updateMemberStatus(updateDate, id);
     }
 
-    /**
-     * 이미지 변경
-     * : 기존 이미지를 삭제하고 새 이미지로 설정
-     * 
-     * @param email : 요청 보낸 사용자의 이메일
-     * @param multipartFile : 변경할 이미지 파일
-     */
-    @Transactional
-    public void updateProfileImage(String email, MultipartFile multipartFile){
-        Member member = memberRepository.findByEmail(email).get();
-        verifyFileType(multipartFile.getContentType());
-
-        if(!member.isBasicImage() && !member.getProfileName().isBlank())
-            deleteProfileImage(member.getProfileName());
-
-        String fileName = createFileName(multipartFile.getOriginalFilename());
-        ObjectMetadata objectMetaData = new ObjectMetadata();
-        objectMetaData.setContentType(multipartFile.getContentType());
-        objectMetaData.setContentLength(multipartFile.getSize());
-        
-        try {
-            amazonS3Client.putObject(BUCKET, fileName, multipartFile.getInputStream(), objectMetaData);
-        } catch (IOException e){
-            throw new BusinessLogicException(MemberExceptionType.IMAGE_BAD_REQUEST);
-        }
-        
-        String imageUrl = amazonS3Client.getUrl(BUCKET, fileName).toString();
-        member.updateProfile(imageUrl, fileName);
+    //멤버 삭제 : Entity
+    public void deleteMember(Member member){
+        memberRepository.delete(member);
     }
 
-    /**
-     * 이미지 초기화
-     * : 기존 이미지를 삭제한 후 기본 이미지로 설정
-     * 
-     * @param email : 요청 보낸 사용자의 이메일
-     */
-    @Transactional
-    public void resetProfileImage(String email) {
-        Member member = memberRepository.findByEmail(email).get();
-        if(member.isBasicImage())
-            throw new BusinessLogicException(MemberExceptionType.IMAGE_CONFLICT);
-        deleteProfileImage(member.getProfileName());
-        member.updateProfile(IMAGE_URL,null);
+    //멤버 List 삭제 : Id List
+    public void deleteMemberByIds(List<Long> deletedMembers){
+        memberRepository.deleteAllByIdInBatch(deletedMembers);
     }
 
+    //멤버 반환 : Id
     public Member getMember(Long memberId){
         return memberRepository.findById(memberId)
                 .orElseThrow( () -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
     }
 
+    //탈퇴하지 않은 멤버인 경우 반환 : Email
+    public Member getNotDeletedMemberByEmail(String email) {
+        return memberRepository.findByEmailAndIsDeletedFalse(email)
+                .orElseThrow(() -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
+    }
+
+    //멤버 조회 : Email
+    public Member getMemberByEmailWithoutThrowingException(String email){
+        return memberRepository.findByEmail(email).get();
+    }
+
+    //멤버 조회 후 탈퇴한 회원인지 확인 : Email
+    public Member getMemberByEmail(String email){
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        if(optionalMember.isPresent()) {
+            Member member = optionalMember.get();
+            if (member.isDeleted()){
+                throw new BusinessLogicException(MemberExceptionType.LOCKED);
+            }
+            return member;
+        }
+        return null;
+    }
+
+    //이미 사용중인 이메일인지 여부 조회 : Email
+    public boolean isPresentMemberByEmail(String email){
+        return memberRepository.findByEmail(email).isPresent();
+    }
+
+    //멤버 반환 : Nickname
+    public Member getNotDeletedMemberByNickname(String nickname){
+        return memberRepository.findByNicknameAndIsDeletedFalse(nickname)
+                .orElseThrow(() -> new BusinessLogicException(MemberExceptionType.NOT_FOUND));
+    }
+
+    //이미 사용중인 닉네임인지 여부 조회 : Nickname
+    public boolean isPresentMemberByNickname(String nickname){
+        return memberRepository.findByNickname(nickname).isPresent();
+    }
+
+    //특정 시점을 기준으로 탈퇴한 멤버 List 조회 : LocalDateTime
     public List<Member> findDeletedMemberByModifiedDate(LocalDateTime dateTime){
         return memberRepository.findAllByIsDeletedTrueAndModifiedDateBefore(dateTime);
-    }
-
-    public void deleteMemberByIds(List<Long> deletedMembers){
-        memberRepository.deleteAllByIdInBatch(deletedMembers);
-    }
-
-    private void deleteProfileImage(String fileName){
-        amazonS3Client.deleteObject(BUCKET,fileName);
-    }
-
-    private void verifyFileType(String type) {
-        String[] typeList = {"image/jpeg","image/jpg","image/png"};
-        List<String> strList = new ArrayList<>(Arrays.asList(typeList));
-        if(!strList.contains(type))
-            throw new BusinessLogicException(MemberExceptionType.IMAGE_BAD_REQUEST);
-    }
-
-    private String createFileName(String originalFileName){
-        String type = originalFileName.substring(originalFileName.lastIndexOf("."));
-        String fileName = UUID.randomUUID().toString().concat(type);
-        return fileName;
     }
 }

--- a/src/main/java/com/prolog/prologbackend/Member/Service/Other/ImageService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/Other/ImageService.java
@@ -1,0 +1,60 @@
+package com.prolog.prologbackend.Member.Service.Other;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.prolog.prologbackend.Exception.BusinessLogicException;
+import com.prolog.prologbackend.Member.ExceptionType.MemberExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final AmazonS3Client amazonS3Client;
+    @Value("${S3Bucket}")
+    private String BUCKET;
+
+
+    public String getImageUrl(String fileName) {
+        return amazonS3Client.getUrl(BUCKET, fileName).toString();
+    }
+    public void deleteProfileImage(String fileName){
+        amazonS3Client.deleteObject(BUCKET,fileName);
+    }
+    public String createProfileImage(MultipartFile multipartFile) {
+        verifyFileType(multipartFile.getContentType());
+
+        String fileName = createFileName(multipartFile.getOriginalFilename());
+        ObjectMetadata objectMetaData = new ObjectMetadata();
+        objectMetaData.setContentType(multipartFile.getContentType());
+        objectMetaData.setContentLength(multipartFile.getSize());
+
+        try {
+            amazonS3Client.putObject(BUCKET, fileName, multipartFile.getInputStream(), objectMetaData);
+            return fileName;
+        } catch (IOException e){
+            throw new BusinessLogicException(MemberExceptionType.IMAGE_BAD_REQUEST);
+        }
+    }
+
+    private void verifyFileType(String type) {
+        String[] typeList = {"image/jpeg","image/jpg","image/png"};
+        List<String> strList = new ArrayList<>(Arrays.asList(typeList));
+        if(!strList.contains(type))
+            throw new BusinessLogicException(MemberExceptionType.IMAGE_BAD_REQUEST);
+    }
+
+    private String createFileName(String originalFileName){
+        String type = originalFileName.substring(originalFileName.lastIndexOf("."));
+        String fileName = UUID.randomUUID().toString().concat(type);
+        return fileName;
+    }
+}

--- a/src/main/java/com/prolog/prologbackend/Member/Service/Other/KakaoService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/Other/KakaoService.java
@@ -1,0 +1,71 @@
+package com.prolog.prologbackend.Member.Service.Other;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prolog.prologbackend.Member.DTO.Request.KaKaoInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private final String CONTENT_TYPE = "application/x-www-form-urlencoded;charset=utf-8";
+    @Value("${kakao.id}")
+    private String CLIENT_ID;
+    @Value("${kakao.uri}")
+    private String REDIRECT_URI;
+
+
+    public String getKakaoToken(String code){
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", CONTENT_TYPE);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", CLIENT_ID);
+        body.add("redirect_uri", REDIRECT_URI);
+        body.add("code", code);
+
+        HttpEntity entity = new HttpEntity(body, headers);
+        String requestUrl = "https://kauth.kakao.com/oauth/token";
+
+        ResponseEntity<Map> response =
+                restTemplate.exchange(requestUrl, HttpMethod.POST,entity, Map.class);
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    public KaKaoInfoDto getKakaoInfo(String kakaoToken){
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", CONTENT_TYPE);
+        headers.add("Authorization", kakaoToken);
+
+        HttpEntity sec_entity = new HttpEntity(headers);
+        String requestUrl = "https://kapi.kakao.com/v2/user/me";
+
+        ResponseEntity<String> sec_response =
+                restTemplate.exchange(requestUrl,HttpMethod.POST,sec_entity, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        KaKaoInfoDto responseBody = null;
+        try {
+            responseBody = objectMapper.readValue(sec_response.getBody(), KaKaoInfoDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return responseBody;
+    }
+}

--- a/src/main/java/com/prolog/prologbackend/Member/Service/Other/MailService.java
+++ b/src/main/java/com/prolog/prologbackend/Member/Service/Other/MailService.java
@@ -1,0 +1,54 @@
+package com.prolog.prologbackend.Member.Service.Other;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    @Value("${mail.url.verification}")
+    private String VERIFICATION_URL;
+    @Value("${spring.mail.username}")
+    private String EMAIL;
+
+
+    public void sendIssueCertificationNumber(String email, String code) throws MessagingException {
+        Context context = new Context();
+        context.setVariable("code",code);
+
+
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setFrom(EMAIL);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("[prolog] 인증번호 발급");
+            mimeMessageHelper.setText(templateEngine.process("issueCertificationNumber", context), true);
+
+            javaMailSender.send(mimeMessage);
+    }
+
+    public void sendVerificationEmail(String email, String verificationToken) throws MessagingException {
+        Context context = new Context();
+        context.setVariable("link",VERIFICATION_URL+verificationToken);
+
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setFrom(EMAIL);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("[prolog] 이메일 인증");
+            mimeMessageHelper.setText(templateEngine.process("verificationEmail", context), true);
+
+            javaMailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/prolog/prologbackend/Security/Authentication/CustomAuthenticationFilter.java
+++ b/src/main/java/com/prolog/prologbackend/Security/Authentication/CustomAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.prolog.prologbackend.Security.Authentication;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prolog.prologbackend.Exception.BusinessLogicException;
 import com.prolog.prologbackend.Exception.ErrorResponse;
 import com.prolog.prologbackend.Exception.ExceptionType;
 import com.prolog.prologbackend.Member.Domain.Member;
@@ -35,6 +36,9 @@ public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFi
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try{
+            if(!request.getMethod().equals("POST"))
+                throw new BusinessLogicException(SecurityExceptionType.METHOD_NOT_ALLOWED);
+
             ObjectMapper om = new ObjectMapper();
             Member member = om.readValue(request.getInputStream(), Member.class);
 
@@ -42,8 +46,10 @@ public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFi
             Authentication authResult = this.getAuthenticationManager().authenticate(authenticationToken);
             SecurityContextHolder.getContext().setAuthentication(authResult);
             return authResult;
-        } catch(IOException e) {
-            e.printStackTrace();
+        } catch(IOException exception) {
+            exception.printStackTrace();
+        } catch (BusinessLogicException exception) {
+            setErrorResponse(response, exception.getExceptionType());
         }
         return null;
     }

--- a/src/main/java/com/prolog/prologbackend/Security/Authorization/CustomAuthorizationFilter.java
+++ b/src/main/java/com/prolog/prologbackend/Security/Authorization/CustomAuthorizationFilter.java
@@ -38,6 +38,9 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
         } else {
             try {
                 String token = jwtProvider.substringToken(request.getHeader("Token"));
+                if(token == null)
+                    throw new BusinessLogicException(SecurityExceptionType.BAD_REQUEST);
+
                 Claims claims = jwtProvider.parseToken(token);
                 String email = jwtProvider.getEmail(claims);
 

--- a/src/main/java/com/prolog/prologbackend/Security/ExceptionType/SecurityExceptionType.java
+++ b/src/main/java/com/prolog/prologbackend/Security/ExceptionType/SecurityExceptionType.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 public enum SecurityExceptionType implements ExceptionType {
     //인증 예외
+    BAD_REQUEST(400,"잘못된 요청입니다. 확인해주세요."),
     BAD_CREDENTIALS(401, "비밀번호가 일치하지 않습니다."),
+    METHOD_NOT_ALLOWED(405, "지원하지 않는 메서드 입니다."),
     NOT_FOUND(404,"일치하는 회원이 없습니다."),
     DISABLED(422,"이메일을 인증해주세요."),
     LOCKED(423,"탈퇴한 회원입니다."),

--- a/src/main/java/com/prolog/prologbackend/Security/Logout/CustomLogoutFilter.java
+++ b/src/main/java/com/prolog/prologbackend/Security/Logout/CustomLogoutFilter.java
@@ -43,7 +43,13 @@ public class CustomLogoutFilter extends LogoutFilter {
 
         if(requiresLogout(httpServletRequest, httpServletResponse)) {
             try {
+                if(!httpServletRequest.getMethod().equals("POST"))
+                    throw new BusinessLogicException(SecurityExceptionType.METHOD_NOT_ALLOWED);
+
                 String accessToken = httpServletRequest.getHeader("Token");
+                if(accessToken == null)
+                    throw new BusinessLogicException(SecurityExceptionType.BAD_REQUEST);
+
                 String subToken = jwtProvider.substringToken(accessToken);
                 Claims claims = jwtProvider.parseToken(subToken);
                 jwtProvider.verifyType(JwtType.ACCESS_TOKEN, claims);

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
@@ -1,11 +1,8 @@
 package com.prolog.prologbackend.TeamMember.Controller;
 
 import com.prolog.prologbackend.Member.Domain.Member;
-import com.prolog.prologbackend.Member.Service.MemberService;
-import com.prolog.prologbackend.Project.Domain.Project;
-import com.prolog.prologbackend.Project.Service.ProjectService;
 import com.prolog.prologbackend.TeamMember.DTO.Request.CreateTeamMemberDto;
-import com.prolog.prologbackend.TeamMember.Service.TeamMemberService;
+import com.prolog.prologbackend.TeamMember.Service.TeamMemberFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,9 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 public class TeamMemberController {
-    private final TeamMemberService teamMemberService;
-    private final MemberService memberService;
-    private final ProjectService projectService;
+    private final TeamMemberFacadeService teamMemberFacadeService;
 
     @Operation(summary = "팀멤버 등록 메서드")
     @ApiResponses(value = {
@@ -37,9 +32,7 @@ public class TeamMemberController {
     })
     @PostMapping("/teamMembers")
     public ResponseEntity<Void> createTeamMember(@Valid @RequestBody CreateTeamMemberDto createTeamMemberDto){
-        Project project = projectService.getProject(createTeamMemberDto.getProjectId());
-        Member member = memberService.getMember(createTeamMemberDto.getMemberId());
-        teamMemberService.createTeamMember(project, member, createTeamMemberDto.getParts());
+        teamMemberFacadeService.createTeamMember(createTeamMemberDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -56,7 +49,7 @@ public class TeamMemberController {
             @AuthenticationPrincipal Member member,
             @Schema(description = "Path Variable. 삭제할 팀멤버 id", example = "2")
             @PathVariable("team-id") Long teamId){
-        teamMemberService.removeTeamMember(member, teamId);
+        teamMemberFacadeService.deleteTeamMember(member, teamId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Controller/TeamMemberController.java
@@ -2,7 +2,7 @@ package com.prolog.prologbackend.TeamMember.Controller;
 
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.TeamMember.DTO.Request.CreateTeamMemberDto;
-import com.prolog.prologbackend.TeamMember.Service.TeamMemberFacadeService;
+import com.prolog.prologbackend.TeamMember.Service.Facade.TeamMemberFacadeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Service/Facade/TeamMemberFacadeService.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Service/Facade/TeamMemberFacadeService.java
@@ -1,4 +1,4 @@
-package com.prolog.prologbackend.TeamMember.Service;
+package com.prolog.prologbackend.TeamMember.Service.Facade;
 
 import com.prolog.prologbackend.Member.Domain.Member;
 import com.prolog.prologbackend.Member.Service.MemberService;
@@ -7,6 +7,7 @@ import com.prolog.prologbackend.Project.Service.ProjectService;
 import com.prolog.prologbackend.TeamMember.DTO.Request.CreateTeamMemberDto;
 import com.prolog.prologbackend.TeamMember.Domain.Part;
 import com.prolog.prologbackend.TeamMember.Domain.TeamMember;
+import com.prolog.prologbackend.TeamMember.Service.TeamMemberService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class TeamMemberFacadeService {
     private final TeamMemberService teamMemberService;
     private final MemberService memberService;
     private final ProjectService projectService;
+
 
     /**
      * 필요한 정보를 받아 새 팀멤버 등록

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberFacadeService.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberFacadeService.java
@@ -1,0 +1,59 @@
+package com.prolog.prologbackend.TeamMember.Service;
+
+import com.prolog.prologbackend.Member.Domain.Member;
+import com.prolog.prologbackend.Member.Service.MemberService;
+import com.prolog.prologbackend.Project.Domain.Project;
+import com.prolog.prologbackend.Project.Service.ProjectService;
+import com.prolog.prologbackend.TeamMember.DTO.Request.CreateTeamMemberDto;
+import com.prolog.prologbackend.TeamMember.Domain.Part;
+import com.prolog.prologbackend.TeamMember.Domain.TeamMember;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TeamMemberFacadeService {
+    private final TeamMemberService teamMemberService;
+    private final MemberService memberService;
+    private final ProjectService projectService;
+
+    /**
+     * 필요한 정보를 받아 새 팀멤버 등록
+     *
+     * @param teamMemberDto : 팀멤버 생성에 필요한 정보가 담긴 DTO
+     */
+    @Transactional
+    public void createTeamMember(CreateTeamMemberDto teamMemberDto){
+        Project project = projectService.getProject(teamMemberDto.getProjectId());
+        Member member = memberService.getMember(teamMemberDto.getMemberId());
+        teamMemberService.getEntityConflictByMemberAndProject(member,project);
+
+        String part = teamMemberDto.getParts().stream().map(Part::toString).collect(Collectors.joining(","));
+
+        TeamMember teamMember = TeamMember.builder()
+                .part(part).member(member).project(project)
+                .build();
+
+        teamMemberService.createTeamMember(teamMember);
+    }
+
+    /**
+     * 팀멤버의 id를 받아 해당 팀멤버의 정보 삭제
+     *
+     * @param member : 요청보낸 사용자의 정보
+     * @param teamId : 삭제를 원하는 팀멤버의 id
+     */
+    @Transactional
+    public void deleteTeamMember(Member member, Long teamId){
+        TeamMember teamMember = teamMemberService.getEntityById(teamId);
+
+        if(teamMember.getMember().getId() != member.getId()) {
+            teamMemberService.getEntityByMemberAndProject(member, teamMember.getProject());
+        }
+
+        teamMemberService.deleteTeamMember(teamMember);
+    }
+}

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
@@ -7,7 +7,6 @@ import com.prolog.prologbackend.TeamMember.Domain.Part;
 import com.prolog.prologbackend.TeamMember.Domain.TeamMember;
 import com.prolog.prologbackend.TeamMember.Exception.TeamMemberExceptionType;
 import com.prolog.prologbackend.TeamMember.Repository.TeamMemberRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamMemberService {
     private final TeamMemberRepository teamMemberRepository;
+
 
     //팀멤버 생성
     public void createTeamMember(TeamMember teamMember) {

--- a/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
+++ b/src/main/java/com/prolog/prologbackend/TeamMember/Service/TeamMemberService.java
@@ -13,93 +13,47 @@ import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TeamMemberService {
     private final TeamMemberRepository teamMemberRepository;
 
-    /**
-     * 필요한 정보를 받아 새 팀멤버 등록
-     *
-     * @param project : 소속 프로젝트 정보
-     * @param member : 등록할 회원 정보
-     * @param parts : 프로젝트 내 역할 목록
-     */
-    @Transactional
-    public void createTeamMember(Project project, Member member, List<Part> parts) {
-        teamMemberRepository.findByMemberAndProject(member,project)
-                .ifPresent( t -> { throw new BusinessLogicException(TeamMemberExceptionType.CONFLICT); });
-
-        String part = parts.stream().map(Part::toString).collect(Collectors.joining(","));
-
-        TeamMember teamMember = TeamMember.builder()
-                .part(part).member(member).project(project)
-                .build();
-
+    //팀멤버 생성
+    public void createTeamMember(TeamMember teamMember) {
         teamMemberRepository.save(teamMember);
     }
 
-    /**
-     * 팀멤버의 id를 받아 해당 팀멤버의 정보 삭제
-     *
-     * @param member : 요청보낸 사용자의 정보
-     * @param teamId : 삭제를 원하는 팀멤버의 id
-     */
-    @Transactional
-    public void removeTeamMember(Member member, Long teamId){
-        TeamMember teamMember = getEntityById(teamId);
-
-        if(teamMember.getMember().getId() != member.getId()) {
-            getEntityByMemberAndProject(member, teamMember.getProject());
-        }
-
+    //팀멤버 삭제 : Entity
+    public void deleteTeamMember(TeamMember teamMember){
         teamMemberRepository.delete(teamMember);
     }
 
-    /**
-     * 팀멤버 id 목록에 해당하는 엔티티 삭제
-     * : 회원 탈퇴 시 호출
-     *
-     * @param teamMembersIds : 삭제할 팀멤버의 id 목록
-     */
-    @Transactional
-    public void removeTeamMember(List<Long> teamMembersIds){
+    //팀멤버 삭제 : Id List
+    public void deleteTeamMemberByIds(List<Long> teamMembersIds){
         teamMemberRepository.deleteAllByIdInBatch(teamMembersIds);
     }
 
-    /**
-     * 프로젝트 정보와 일치하는 모든 팀멤버의 엔티티를 반환
-     * : 프로젝트 상세 정보 조회 시 호출
-     *
-     * @param project : 프로젝트 기준으로 팀멤버 조회
-     * @return : 조회된 팀멤버 엔티티의 목록 반환
-     */
+    //팀멤버 조회 : Id
+    public TeamMember getEntityById(Long teamMemberId){
+        return teamMemberRepository.findById(teamMemberId).orElseThrow(() -> {
+            throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND);
+        });
+    }
+
+    //팀멤버 List 반환 : Entity (Project)
     public List<TeamMember> getListByProject(Project project){
         return teamMemberRepository.findAllByProject(project).orElseThrow(
                 () -> { throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND); }
         );
     }
 
-    /**
-     * 회원 정보와 일치하는 모든 팀멤버의 엔티티를 반환
-     * : 마이페이지 프로젝트 목록 조회 시 호출
-     *
-     * @param member : 회원 기준으로 팀멤버 조회
-     * @return : 조회된 팀멤버 엔티티의 목록 반환
-     */
+    //팀멤버 List 반환 : Entity (Member)
     public List<TeamMember> getListByMember(Member member){
         return teamMemberRepository.findAllByMember(member);
     }
 
-    /**
-     * 특정 회원의 특정 프로젝트와 일치하는 팀멤버 엔티티 조회
-     * : 특정 회원의 일지 목록 조회 시 호출
-     *
-     * @param member : 회원 기준으로 팀멤버 조회
-     * @param project : 프로젝트 기준으로 팀멤버 조회
-     */
+    //존재하는 팀멤버인지 확인 & 프로젝트의 리더인지 확인 : Entity (Member, Project)
     public void getEntityByMemberAndProject(Member member, Project project){
         String part = teamMemberRepository.findByMemberAndProject(member, project)
                 .orElseThrow(() -> {
@@ -110,15 +64,9 @@ public class TeamMemberService {
             throw new BusinessLogicException(TeamMemberExceptionType.FORBIDDEN);
     }
 
-    /**
-     * 팀멤버 ID로 엔티티 조회
-     *
-     * @param teamMemberId : 조회할 팀멤버 id
-     * @return : 조회된 팀멤버 엔티티 반환
-     */
-    public TeamMember getEntityById(Long teamMemberId){
-        return teamMemberRepository.findById(teamMemberId).orElseThrow(() -> {
-            throw new BusinessLogicException(TeamMemberExceptionType.NOT_FOUND);
-        });
+    //이미 존재하는지 확인 : Entity (Member, Project)
+    public void getEntityConflictByMemberAndProject(Member member, Project project){
+        teamMemberRepository.findByMemberAndProject(member,project)
+                .ifPresent( t -> { throw new BusinessLogicException(TeamMemberExceptionType.CONFLICT); });
     }
 }

--- a/src/main/resources/templates/issueCertificationNumber.html
+++ b/src/main/resources/templates/issueCertificationNumber.html
@@ -10,11 +10,11 @@
         비밀번호 재설정 시 사용될 인증번호를 발급해드립니다.</p>
     <br>
     <div align="center" style="border:1px solid black;">
-        <p style=margin:20px;">
+        <p style="margin:20px;">
             인증 번호 입니다<br>
             ❗5분 내로 입력해주세요❗<br>
         </p>
-        <div style="color:blue" th:text="${code}"></div>
+        <div style="color:blue; font-size:17px" th:text="${code}"></div>
     </div>
 </body>
 </html>

--- a/src/main/resources/templates/verificationEmail.html
+++ b/src/main/resources/templates/verificationEmail.html
@@ -8,7 +8,9 @@
     <h3>이메일 인증</h3>
     <p>안녕하세요🌟 개발일지 프로젝트 Prolog 입니다.<br>
         서비스 이용을 위한 이메일 인증 단계입니다.<br>
-        아래의 링크를 클릭하여 인증을 완료해주세요!</p>
+        아래의 링크를 클릭하여 인증을 완료해주세요!
+    </p>
+    <br>
     <a style="color:gray; font-size: 17px" th:href="${link}">🔗LINK</a>
 </body>
 </html>


### PR DESCRIPTION
## 🔗관련 이슈
* resolve : #56 
## 📑세부 내용
* **기능 추가**
  * CORS 설정
  * 팀멤버 추가를 위한 회원 조회
  * 스케줄러로 탈퇴 회원 DB 내 삭제
* **기능 수정**
  * Facade Layer 추가
  * Image, Kakao, Mail Service 분리
  * 회원 정보 수정 항목 변경
  * 로그인, 로그아웃 HTTP request method POST로 제한
## ✍️추가 설명
* Member, TeamMember Service 클래스를 분리했습니다.
  * 공통
    * DB에 접근하는 메서드는 기본 Service
      * Facade Service에서 사용되는 서비스 클래스
       * 도메인 당 하나만 존재
    * 여러 서비스를 호출하며 기능을 수행하는 메서드는 Facade Service
      * Controller에서 사용되는 서비스 클래스
      * 도메인 당 필요에 따라 여러개 생성 가능
  * Member Service
    * S3에 접근하는 메서드는 Image Service
    * 소셜 로그인 시 카카오 서버와 통신하는 메서드는 Kakao Service
    * 사용자에게 메일을 전송하는 메서드는 Mail Service
* ScheduledConfig에 탈퇴 멤버 삭제 메서드를 추가하였습니다.
* SpringSecurityConfig에 CORS 설정을 추가하였습니다. 